### PR TITLE
Fix client dsc script invoke with spaces in path

### DIFF
--- a/DSCResources/RS_rsMofs/RS_rsMofs.psm1
+++ b/DSCResources/RS_rsMofs/RS_rsMofs.psm1
@@ -169,15 +169,12 @@ function Set-TargetResource
                 {
                     Write-Verbose "Recreating mofs for $srvname"
                     RemoveMof -uuid $($server.uuid) -MofPath $mofDestPath
-                                        
-                    Write-Verbose "Calling $confFile `n $server.NodeName `n $server.uuid"
-                                        
-                    Invoke-Expression "$($confFile) -Node $($server.NodeName) -Objectuuid $($server.uuid)"
+                    Write-Verbose "Calling $confFile `n $server.NodeName `n $server.uuid"                   
+                    & "$($confFile) -Node $($server.NodeName) -Objectuuid $($server.uuid)"
                 }
                 catch 
                 {
                     Write-Verbose "Error creating mof for $($server.NodeName) using $confFile `n$($_.Exception.message)"
-                    #Write-EventLog -LogName DevOps -Source $logSource -EntryType Error -EventId 1002 -Message "Error creating mof for $($server.NodeName) using $confFile `n$($_.Exception.message)"
                 }
             }
         }
@@ -235,7 +232,6 @@ function Test-TargetResource
             Write-Verbose "WARNING: A configuration file referenced in $nodeData was not found - $confFile"
         }
     }
-        
     # Check if each node has a mof and checksum present
     foreach($server in $allServers)
     {
@@ -273,7 +269,6 @@ function Test-TargetResource
     {
         return $false
     }
-
     return $true
 }
 

--- a/DSCResources/RS_rsMofs/RS_rsMofs.psm1
+++ b/DSCResources/RS_rsMofs/RS_rsMofs.psm1
@@ -170,7 +170,7 @@ function Set-TargetResource
                     Write-Verbose "Recreating mofs for $srvname"
                     RemoveMof -uuid $($server.uuid) -MofPath $mofDestPath
                     Write-Verbose "Calling $confFile `n $server.NodeName `n $server.uuid"                   
-                    & "$($confFile) -Node $($server.NodeName) -Objectuuid $($server.uuid)"
+                    & $confFile -Node $server.NodeName -Objectuuid $server.uuid
                 }
                 catch 
                 {

--- a/rsMofs.psd1
+++ b/rsMofs.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '3.0.1'
+ModuleVersion = '3.0.2'
 
 # ID used to uniquely identify this module
 GUID = '52ae92b7-4820-418a-b731-6088a491571e'


### PR DESCRIPTION
Switching to the ampersand to execute the external DSC scripts allows for spaces in the script path to be present without having to escape them as is the case with Invoke-Expression. 

closes issue #17 
